### PR TITLE
add filename into error message in compile

### DIFF
--- a/lib/xtemplate/compiler.js
+++ b/lib/xtemplate/compiler.js
@@ -576,7 +576,18 @@ compiler = {
      */
     parse: function (tplContent, name) {
         if (tplContent) {
-            return parser.parse(tplContent, name);
+            var parsed;
+                try {
+                    parsed = parser.parse(tplContent, name);
+                } catch (e) {
+                    if (name && e.message.indexOf('in file:') === -1) {
+                        // for debug info
+                        var prefix = name ? 'in file: ' + name + ' ' : '';
+                        e.message = prefix + e.message;
+                    }
+                    throw e;
+                }
+                return parsed;
         } else {
             return {
                 statements: []


### PR DESCRIPTION
for debug, fixed #31 

或者可以考虑 kison 中不用加这个 `prefix` 统一让外层自己加？这样这里就不需要多判断一次了，不过都差不多..
