### PR TITLE
Export dynamic version on standalone-build to match kclean-normalize-mod-name

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -83,14 +83,17 @@ gulp.task('xtemplate-standalone', function () {
   packages[fullName] = {
     base: path.resolve(src)
   };
+
+  var exportVer = packageInfo.version.replace(/\./g, '');
+
   var wrap = {
     index: {
       start: 'var XTemplate = (function(){ var module = {};\n',
-      end: '\nreturn xtemplate403Index;\n})();'
+      end: '\nreturn xtemplate' + exportVer + 'Index;\n})();'
     },
     runtime: {
       start: 'var XTemplateRuntime = (function(){ var module = {};\n',
-      end: '\nreturn xtemplate403Runtime;\n})();'
+      end: '\nreturn xtemplate' + exportVer + 'Runtime;\n})();'
     }
   };
   ['index', 'runtime'].forEach(function (mod) {


### PR DESCRIPTION
更新 standalone的規則，使導出的變量名稱符合kclean編譯邏輯。

這不是長久之計，需要請淘杰拆出 normalizeModuleName的api才行。
現在kclean那部分的代碼耦合的太嚴重，無法直接使用，只能在gulp這邊硬編碼處理。