### PR TITLE
use faster escapeHtml

### DIFF
--- a/benchmark/escape_html.js
+++ b/benchmark/escape_html.js
@@ -1,0 +1,50 @@
+
+/**
+ * Globals for benchmark.js
+ */
+global.escapeHtml = require('../lib/runtime/util').escapeHtml;
+
+/**
+ * Module dependencies.
+ */
+var benchmark = require('benchmark');
+var benchmarks = require('beautify-benchmark');
+
+for (var dep in process.versions) {
+  console.log('  %s@%s', dep, process.versions[dep]);
+}
+
+console.log('');
+
+var suite = new benchmark.Suite;
+
+suite.add({
+  'name': 'no special characters',
+  'minSamples': 100,
+  'fn': 'escapeHtml(str)',
+  'setup': 'str = "Hello, World!"'
+});
+
+suite.add({
+  'name': 'single special character',
+  'minSamples': 100,
+  'fn': 'escapeHtml(str)',
+  'setup': 'str = "Hello, World&!"'
+});
+
+suite.add({
+  'name': 'many special characters',
+  'minSamples': 100,
+  'fn': 'escapeHtml(str)',
+  'setup': 'str = "\'>\'\\"\\"&>h<e>&<y>"'
+});
+
+suite.on('cycle', function onCycle(event) {
+  benchmarks.add(event.target);
+});
+
+suite.on('complete', function onComplete() {
+  benchmarks.log();
+});
+
+suite.run({'async': false});

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "lib"
   ],
   "devDependencies": {
+    "beautify-benchmark": "~0.2.4",
+    "benchmark": "~1.0.0",
     "expect.js": "^0.3.1",
     "gulp": "^3.8.7",
     "gulp-xtemplate": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
   "files": [
     "lib"
   ],
+  "dependencies": {
+    "escape-html": "~1.0.3"
+  },
   "devDependencies": {
     "beautify-benchmark": "~0.2.4",
     "benchmark": "~1.0.0",

--- a/src/runtime/util.js
+++ b/src/runtime/util.js
@@ -1,6 +1,8 @@
 // http://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
 // http://wonko.com/post/html-escaping
-const possibleEscapeHtmlReg = /[&<>"'`\/]/;
+
+const escapeHtml = require('escape-html');
+
 const SUBSTITUTE_REG = /\\?\{([^{}]+)\}/g;
 const win = typeof global !== 'undefined' ? global : window;
 
@@ -85,58 +87,7 @@ module.exports = util = {
     });
   },
 
-  escapeHtml: function (string) {
-    const str = '' + string;
-    const match = possibleEscapeHtmlReg.exec(str);
-
-    if (!match) {
-      return str;
-    }
-
-    let escape;
-    let html = '';
-    let index = 0;
-    let lastIndex = 0;
-
-    for (index = match.index; index < str.length; index++) {
-      switch (str.charCodeAt(index)) {
-      case 34: // "
-        escape = '&quot;';
-        break;
-      case 38: // &
-        escape = '&amp;';
-        break;
-      case 39: // '
-        escape = '&#39;';
-        break;
-      case 60: // <
-        escape = '&lt;';
-        break;
-      case 62: // >
-        escape = '&gt;';
-        break;
-      case 96: // `
-        escape = '&#x60;';
-        break;
-      case 47: // /
-        escape = '&#x2F;';
-        break;
-      default:
-        continue;
-      }
-
-      if (lastIndex !== index) {
-        html += str.substring(lastIndex, index);
-      }
-
-      lastIndex = index + 1;
-      html += escape;
-    }
-
-    return lastIndex !== index
-      ? html + str.substring(lastIndex, index)
-      : html;
-  },
+  escapeHtml: escapeHtml,
 
   merge() {
     let i = 0;


### PR DESCRIPTION
实现来自于： https://github.com/component/escape-html ，增加了 xtemplate 里面会转义的字符。

before:

```
no special characters    x 22,928,859 ops/sec ±0.98% (191 runs sampled)
single special character x  1,926,023 ops/sec ±0.83% (187 runs sampled)
many special characters  x    687,743 ops/sec ±0.98% (187 runs sampled)
```

after:

```
no special characters    x 22,687,378 ops/sec ±0.79% (192 runs sampled)
single special character x  6,571,191 ops/sec ±1.33% (190 runs sampled)
many special characters  x  3,465,183 ops/sec ±1.01% (191 runs sampled)
```