### PR TITLE
fix: prefer to resolve from affix

### DIFF
--- a/src/runtime/scope.js
+++ b/src/runtime/scope.js
@@ -56,7 +56,7 @@ Scope.prototype = {
     let v;
     const affix = this.affix;
 
-    if (data !== null && data !== undefined) {
+    if (data !== null && data !== undefined && affix[name] === undefined) {
       v = data[name];
     }
 


### PR DESCRIPTION
here is an example:

data
```
{
  ‘startDate': 'Wed Nov 02 2016 14:07:56 GMT+0800 (CST)'
}
```

xtpl (pass data as root):
```
{{set (startDate = $utils.moment('Wed Nov 02 2016 14:07:56 GMT+0800 (CST)', 'YYYY-MM-DD hh:mm:ss').toDate())}}
{{startDate.getTime()}}
```

it will retrieve `startDate` from origin data, not affix